### PR TITLE
Add "uaccess" to udev rules

### DIFF
--- a/50_ems_gb_flash.rules
+++ b/50_ems_gb_flash.rules
@@ -1,2 +1,2 @@
 # EMS USB 64M Gameboy flash cart
-ATTRS{idVendor}=="4670", ATTRS{idProduct}=="9394", MODE="0664", GROUP="plugdev"
+ATTRS{idVendor}=="4670", ATTRS{idProduct}=="9394", MODE="0664", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
I needed this to make the udev rules work on Arch Linux.